### PR TITLE
ICML 2020 - Missing DOI links or pdf links in citation column

### DIFF
--- a/_includes/workshops/icml/icml2020.html
+++ b/_includes/workshops/icml/icml2020.html
@@ -68,7 +68,7 @@
                 <td style="max-width: 1px;" class="tg-0lax">
                   {{paper.publicationauthor}}, ({{paper.year}}). <i>{{paper.title}}</i> [{{paper.type}} Presentation]. 
                   International Conference on Machine Learning: LatinX in AI (LXAI) Research Workshop {{paper.year}}, {{paper.location}}.
-                  <a style="overflow-wrap: break-word; white-space: normal;" href="{{paper.link}}">{{paper.link}}</a>
+                  <a target="_blank" style="overflow-wrap: break-word; white-space: normal;" href="{{paper.link}}">{{paper.link}}</a>
                 </td>
               </tr>
               <!--Finish one author-->
@@ -143,7 +143,7 @@
                 <td style="max-width: 1px;" class="tg-0lax">
                   {{paper.publicationauthor}}, ({{paper.year}}). <i>{{paper.title}}</i> [{{paper.type}} Presentation]. 
                   International Conference on Machine Learning: LatinX in AI (LXAI) Research Workshop {{paper.year}}, {{paper.location}}.
-                  <a style="overflow-wrap: break-word; white-space: normal;" href="{{paper.link}}">{{paper.link}}</a>
+                  <a target="_blank" style="overflow-wrap: break-word; white-space: normal;" href="{{paper.link}}">{{paper.link}}</a>
                 </td>
               </tr>
               <!--Finish one author-->
@@ -184,7 +184,7 @@
                 <td style="max-width: 1px;" class="tg-0lax">
                   {{paper.publicationauthor}}, ({{paper.year}}). <i>{{paper.title}}</i> [{{paper.type}} Presentation]. 
                   International Conference on Machine Learning: LatinX in AI (LXAI) Research Workshop {{paper.year}}, {{paper.location}}.
-                  <a style="overflow-wrap: break-word; white-space: normal;" href="{{paper.link}}">{{paper.link}}</a>
+                  <a target="_blank" style="overflow-wrap: break-word; white-space: normal;" href="{{paper.link}}">{{paper.link}}</a>
                 </td>
               </tr>
               <!--Finish one author-->
@@ -225,7 +225,7 @@
                 <td style="max-width: 1px;" class="tg-0lax">
                   {{paper.publicationauthor}}, ({{paper.year}}). <i>{{paper.title}}</i> [{{paper.type}} Presentation]. 
                   International Conference on Machine Learning: LatinX in AI (LXAI) Research Workshop {{paper.year}}, {{paper.location}}.
-                  <a style="overflow-wrap: break-word; white-space: normal;" href="{{paper.link}}">{{paper.link}}</a>
+                  <a target="_blank" style="overflow-wrap: break-word; white-space: normal;" href="{{paper.link}}">{{paper.link}}</a>
                 </td>
               </tr>
               <!--Finish one author-->

--- a/_posts/2020_icml/2020-05-24-Ayala.md
+++ b/_posts/2020_icml/2020-05-24-Ayala.md
@@ -9,7 +9,7 @@ alt: --
 type: Poster
 topic: Deep Learning
 subtopic: Machine Learning
-link: 
+link: https://research.latinxinai.org/papers/icml/2020/pdf/Poster_Angel_Ayala.pdf
 conference: icml
 year: 2020
 tags: icml-2020

--- a/_posts/2020_icml/2020-05-24-Braga.md
+++ b/_posts/2020_icml/2020-05-24-Braga.md
@@ -9,7 +9,7 @@ alt: --
 type: Oral
 topic: Deep Learning
 subtopic: Machine Learning
-link: 
+link: https://research.latinxinai.org/papers/icml/2020/pdf/Oral_Pedro_Braga.pdf
 conference: icml
 year: 2020
 tags: icml-2020-op

--- a/_posts/2020_icml/2020-05-24-Castillo.md
+++ b/_posts/2020_icml/2020-05-24-Castillo.md
@@ -9,7 +9,7 @@ alt: --
 type: Poster
 topic: Reinforcement Learning
 subtopic: Applications
-link: 
+link: https://research.latinxinai.org/papers/icml/2020/pdf/Poster_Guillermo_Castillo.pdf
 conference: icml
 year: 2020
 tags: icml-2020

--- a/_posts/2020_icml/2020-05-24-Cordeiro.md
+++ b/_posts/2020_icml/2020-05-24-Cordeiro.md
@@ -9,7 +9,7 @@ alt: --
 type: Poster
 topic: Applications
 subtopic: Machine Learning
-link: 
+link: https://research.latinxinai.org/papers/icml/2020/pdf/Poster_Douglas_Cordeiro.pdf
 conference: icml
 year: 2020
 tags: icml-2020

--- a/_posts/2020_icml/2020-05-24-DaSilva.md
+++ b/_posts/2020_icml/2020-05-24-DaSilva.md
@@ -9,7 +9,7 @@ alt: --
 type: Poster
 topic: Applications
 subtopic: Machine Learning
-link: 
+link: https://research.latinxinai.org/papers/icml/2020/pdf/Poster_Nubia_DaSilva.pdf
 conference: icml
 year: 2020
 tags: icml-2020

--- a/_posts/2020_icml/2020-05-24-Diaz.md
+++ b/_posts/2020_icml/2020-05-24-Diaz.md
@@ -9,7 +9,7 @@ alt: --
 type: Poster
 topic: Applications
 subtopic: Machine Learning
-link: 
+link: https://research.latinxinai.org/papers/icml/2020/pdf/Poster_Diana_Diaz.pdf
 conference: icml
 year: 2020
 tags: icml-2020-nopitch

--- a/_posts/2020_icml/2020-05-24-Espin1.md
+++ b/_posts/2020_icml/2020-05-24-Espin1.md
@@ -9,7 +9,7 @@ alt: --
 type: Oral
 topic: Machine Learning
 subtopic: Applications
-link: 
+link: https://research.latinxinai.org/papers/icml/2020/pdf/Oral_Lisette_Espin1.pdf
 conference: icml
 year: 2020
 tags: icml-2020-op

--- a/_posts/2020_icml/2020-05-24-Espin2.md
+++ b/_posts/2020_icml/2020-05-24-Espin2.md
@@ -9,7 +9,7 @@ alt: --
 type: Poster
 topic: Applications
 subtopic: Machine Learning
-link: 
+link: https://research.latinxinai.org/papers/icml/2020/pdf/Poster_Lisette_Espin2.pdf
 conference: icml
 year: 2020
 tags: icml-2020

--- a/_posts/2020_icml/2020-05-24-Garrido.md
+++ b/_posts/2020_icml/2020-05-24-Garrido.md
@@ -9,7 +9,7 @@ alt: --
 type: Oral
 topic: Applications
 subtopic: Machine Learning
-link: 
+link: https://research.latinxinai.org/papers/icml/2020/pdf/Oral_Sergio_Garrido.pdf
 conference: icml
 year: 2020
 tags: icml-2020-op

--- a/_posts/2020_icml/2020-05-24-Meraz.md
+++ b/_posts/2020_icml/2020-05-24-Meraz.md
@@ -9,7 +9,7 @@ alt: --
 type: Poster
 topic: Machine Learning
 subtopic: Applications
-link: 
+link: https://research.latinxinai.org/papers/icml/2020/pdf/Poster_Vanessa_Meraz.pdf
 conference: icml
 year: 2020
 tags: icml-2020-np

--- a/_posts/2020_icml/2020-05-24-Moreira.md
+++ b/_posts/2020_icml/2020-05-24-Moreira.md
@@ -9,7 +9,7 @@ alt: --
 type: Oral
 topic: Applications
 subtopic: Deep Learning
-link: 
+link: https://research.latinxinai.org/papers/icml/2020/pdf/Oral_Gabriel_Moreira.pdf
 conference: icml
 year: 2020
 tags: icml-2020-op

--- a/_posts/2020_icml/2020-05-24-Munoz.md
+++ b/_posts/2020_icml/2020-05-24-Munoz.md
@@ -9,7 +9,7 @@ alt: --
 type: Oral
 topic: General Machine Learning
 subtopic: Trustworthy Machine Learning
-link: 
+link: https://research.latinxinai.org/papers/icml/2020/pdf/Oral_Andres_Munoz.pdf
 conference: icml
 year: 2020
 tags: icml-2020-op

--- a/_posts/2020_icml/2020-05-24-Murillo.md
+++ b/_posts/2020_icml/2020-05-24-Murillo.md
@@ -9,7 +9,7 @@ alt: --
 type: Poster
 topic: Applications
 subtopic: Machine Learning
-link: 
+link: https://research.latinxinai.org/papers/icml/2020/pdf/Poster_Alejandro_Murillo.pdf
 conference: icml
 year: 2020
 tags: icml-2020

--- a/_posts/2020_icml/2020-05-24-Murrugarra_Llerena.md
+++ b/_posts/2020_icml/2020-05-24-Murrugarra_Llerena.md
@@ -9,7 +9,7 @@ alt: --
 type: Poster
 topic: Applications
 subtopic: Deep Learning
-link: 
+link: https://research.latinxinai.org/papers/icml/2020/pdf/Poster_Jeffri_Murrugarra1.pdf
 conference: icml
 year: 2020
 tags: icml-2020

--- a/_posts/2020_icml/2020-05-24-Ochoa_Ruiz1.md
+++ b/_posts/2020_icml/2020-05-24-Ochoa_Ruiz1.md
@@ -9,7 +9,7 @@ alt: --
 type: Poster
 topic: Machine Learning
 subtopic: Applications
-link: 
+link: https://research.latinxinai.org/papers/icml/2020/pdf/Poster_Gilberto_Ochoa1.pdf
 conference: icml
 year: 2020
 tags: icml-2020

--- a/_posts/2020_icml/2020-05-24-Ochoa_Ruiz2.md
+++ b/_posts/2020_icml/2020-05-24-Ochoa_Ruiz2.md
@@ -9,7 +9,7 @@ alt: --
 type: Oral
 topic: Deep Learning
 subtopic: Applications
-link: 
+link: https://research.latinxinai.org/papers/icml/2020/pdf/Oral_Gilberto_Ochoa2.pdf
 conference: icml
 year: 2020
 tags: icml-2020-op

--- a/_posts/2020_icml/2020-05-24-Palazzo.md
+++ b/_posts/2020_icml/2020-05-24-Palazzo.md
@@ -9,7 +9,7 @@ alt: --
 type: Poster
 topic: Machine Learning
 subtopic: Applications
-link: 
+link: https://research.latinxinai.org/papers/icml/2020/pdf/Poster_Martin_Palazzo.pdf
 conference: icml
 year: 2020
 tags: icml-2020

--- a/_posts/2020_icml/2020-05-24-Palomino.md
+++ b/_posts/2020_icml/2020-05-24-Palomino.md
@@ -9,7 +9,7 @@ alt: --
 type: Poster
 topic: Deep Learning
 subtopic: Machine Learning
-link: 
+link: https://research.latinxinai.org/papers/icml/2020/pdf/Poster_Daniel_Palomino.pdf
 conference: icml
 year: 2020
 tags: icml-2020

--- a/_posts/2020_icml/2020-05-24-Parreira.md
+++ b/_posts/2020_icml/2020-05-24-Parreira.md
@@ -9,7 +9,7 @@ alt: --
 type: Poster
 topic: Machine Learning
 subtopic: Applications
-link: 
+link: https://research.latinxinai.org/papers/icml/2020/pdf/Poster_Pedro_Parreira.pdf
 conference: icml
 year: 2020
 tags: icml-2020

--- a/_posts/2020_icml/2020-05-24-Polo.md
+++ b/_posts/2020_icml/2020-05-24-Polo.md
@@ -9,7 +9,7 @@ alt: --
 type: Poster
 topic: Applications
 subtopic: Deep Learning
-link: 
+link: https://research.latinxinai.org/papers/icml/2020/pdf/Poster_Felipe_Polo.pdf
 conference: icml
 year: 2020
 tags: icml-2020

--- a/_posts/2020_icml/2020-05-24-Ramirez.md
+++ b/_posts/2020_icml/2020-05-24-Ramirez.md
@@ -9,7 +9,7 @@ alt: --
 type: Poster
 topic: Deep Learning
 subtopic: Computer Vision
-link: 
+link: https://research.latinxinai.org/papers/icml/2020/pdf/Poster_Lourdes_Ramirez.pdf
 conference: icml
 year: 2020
 tags: icml-2020

--- a/_posts/2020_icml/2020-05-24-Ribero.md
+++ b/_posts/2020_icml/2020-05-24-Ribero.md
@@ -9,7 +9,7 @@ alt: --
 type: Poster
 topic: Machine Learning
 subtopic: Deep Learning
-link: 
+link: https://research.latinxinai.org/papers/icml/2020/pdf/Poster_Monica_Ribero.pdf
 conference: icml
 year: 2020
 tags: icml-2020

--- a/_posts/2020_icml/2020-05-24-Rivera.md
+++ b/_posts/2020_icml/2020-05-24-Rivera.md
@@ -9,7 +9,7 @@ alt: --
 type: Poster
 topic: Applications
 subtopic: Deep Learning
-link: 
+link: https://research.latinxinai.org/papers/icml/2020/pdf/Poster_Rodrigo_Rivera.pdf
 conference: icml
 year: 2020
 tags: icml-2020

--- a/_posts/2020_icml/2020-05-24-Ruiz_Perez.md
+++ b/_posts/2020_icml/2020-05-24-Ruiz_Perez.md
@@ -9,7 +9,7 @@ alt: --
 type: Oral
 topic: Machine Learning
 subtopic: Applications
-link: 
+link: https://research.latinxinai.org/papers/icml/2020/pdf/Oral_Daniel_Ruiz.pdf
 conference: icml
 year: 2020
 tags: icml-2020-op

--- a/_posts/2020_icml/2020-05-24-Saire.md
+++ b/_posts/2020_icml/2020-05-24-Saire.md
@@ -9,7 +9,7 @@ alt: --
 type: Poster
 topic: Deep Learning
 subtopic: Applications
-link: 
+link: https://research.latinxinai.org/papers/icml/2020/pdf/Poster_Darwin_Saire.pdf
 conference: icml
 year: 2020
 tags: icml-2020

--- a/_posts/2020_icml/2020-05-24-Saromo.md
+++ b/_posts/2020_icml/2020-05-24-Saromo.md
@@ -9,7 +9,7 @@ alt: --
 type: Oral
 topic: Applications
 subtopic: Deep Learning
-link: 
+link: https://research.latinxinai.org/papers/icml/2020/pdf/Oral_Daniel_Saromo.pdf
 conference: icml
 year: 2020
 tags: icml-2020-op

--- a/_posts/2020_icml/2020-05-24-Serra.md
+++ b/_posts/2020_icml/2020-05-24-Serra.md
@@ -9,7 +9,7 @@ alt: --
 type: Oral
 topic: Deep Learning
 subtopic: General Machine Learning
-link: 
+link: https://research.latinxinai.org/papers/icml/2020/pdf/Oral_Thiago_Serra.pdf
 conference: icml
 year: 2020
 tags: icml-2020-op

--- a/_posts/2020_icml/2020-05-24-Thorne.md
+++ b/_posts/2020_icml/2020-05-24-Thorne.md
@@ -9,7 +9,7 @@ alt: --
 type: Oral
 topic: Applications
 subtopic: Deep Learning
-link: 
+link: https://research.latinxinai.org/papers/icml/2020/pdf/Oral_Camilo_Thorne.pdf
 conference: icml
 year: 2020
 tags: icml-2020-op


### PR DESCRIPTION
The links in the citation column now open in a new tab.