### PR TITLE
ICML 2021 - Missing DOI links or pdf links in citation column

### DIFF
--- a/_includes/workshops/icml/icml2021.html
+++ b/_includes/workshops/icml/icml2021.html
@@ -71,7 +71,7 @@
                 <td style="max-width: 1px;" class="tg-0lax">
                   {{paper.publicationauthor}}, ({{paper.year}}). <i>{{paper.title}}</i> [{{paper.type}} Presentation]. 
                   International Conference on Machine Learning Conference: LatinX in AI (LXAI) Research Workshop {{paper.year}}, {{paper.location}}.
-                  <a style="overflow-wrap: break-word; white-space: normal;" href="{{paper.link}}">{{paper.link}}</a>
+                  <a target="_blank" style="overflow-wrap: break-word; white-space: normal;" href="{{paper.link}}">{{paper.link}}</a>
                 </td>
             </tr>
           <!--Finish one author-->

--- a/_posts/2021_icml/2021-07-07-breno.md
+++ b/_posts/2021_icml/2021-07-07-breno.md
@@ -9,7 +9,7 @@ pitch: https://www.youtube.com/watch?v=yKQSJS00jT0&list=PLFHvi5sdWF5VqqqQvVC5SuB
 type: Oral
 topic: Deep Learning
 category: Extended Abstract
-link: https://research.latinxinai.org/papers/icml/2021/pdf/paper_15.pdf
+link: https://doi.org/10.52591/202107246
 conference: icml
 year: 2021
 tags: icml-2021

--- a/_posts/2021_icml/2021-07-07-carlos.md
+++ b/_posts/2021_icml/2021-07-07-carlos.md
@@ -9,7 +9,7 @@ pitch: https://www.youtube.com/watch?v=bo57OxEHq1Y&list=PLFHvi5sdWF5VqqqQvVC5SuB
 type: Oral
 topic: Deep Learning
 category: Extended Abstract
-link: https://research.latinxinai.org/papers/icml/2021/pdf/paper_29.pdf
+link: https://doi.org/10.52591/2021072411
 conference: icml
 year: 2021
 tags: icml-2021

--- a/_posts/2021_icml/2021-07-07-carmen.md
+++ b/_posts/2021_icml/2021-07-07-carmen.md
@@ -9,7 +9,7 @@ pitch: https://www.youtube.com/watch?v=MO-VFzTYgQg&list=PLFHvi5sdWF5VqqqQvVC5SuB
 type: Oral
 topic: Applications
 category: Extended Abstract
-link: https://research.latinxinai.org/papers/icml/2021/pdf/paper_20.pdf
+link: https://doi.org/10.52591/202107248
 conference: icml
 year: 2021
 tags: icml-2021

--- a/_posts/2021_icml/2021-07-07-emanuel.md
+++ b/_posts/2021_icml/2021-07-07-emanuel.md
@@ -9,7 +9,7 @@ pitch: https://www.youtube.com/watch?v=Im8SP820mwY&list=PLFHvi5sdWF5VqqqQvVC5SuB
 type: Oral
 topic: Deep Learning
 category: Extended Abstract
-link: https://research.latinxinai.org/papers/icml/2021/pdf/paper_28.pdf
+link: https://doi.org/10.52591/2021072410
 conference: icml
 year: 2021
 tags: icml-2021

--- a/_posts/2021_icml/2021-07-07-felipe.md
+++ b/_posts/2021_icml/2021-07-07-felipe.md
@@ -9,7 +9,7 @@ pitch: https://www.youtube.com/watch?v=vTzVkPcdAd0&list=PLFHvi5sdWF5VqqqQvVC5SuB
 type: Oral
 topic: Applications
 category: Extended Abstract
-link: https://research.latinxinai.org/papers/icml/2021/pdf/paper_32.pdf
+link: https://doi.org/10.52591/2021072412
 conference: icml
 year: 2021
 tags: icml-2021

--- a/_posts/2021_icml/2021-07-07-ferran.md
+++ b/_posts/2021_icml/2021-07-07-ferran.md
@@ -9,7 +9,7 @@ pitch: https://www.youtube.com/watch?v=1RAk5EFHvfs&list=PLFHvi5sdWF5VqqqQvVC5SuB
 type: Oral
 topic: Applications
 category: Extended Abstract
-link: https://research.latinxinai.org/papers/icml/2021/pdf/paper_07.pdf
+link: https://doi.org/10.52591/202107244
 conference: icml
 year: 2021
 tags: icml-2021

--- a/_posts/2021_icml/2021-07-07-gerivan.md
+++ b/_posts/2021_icml/2021-07-07-gerivan.md
@@ -9,7 +9,7 @@ pitch: https://www.youtube.com/watch?v=vxWwMt_xGIE&list=PLFHvi5sdWF5VqqqQvVC5SuB
 type: Oral
 topic: Deep Learning
 category: Extended Abstract
-link: https://research.latinxinai.org/papers/icml/2021/pdf/paper_13.pdf
+link: https://doi.org/10.52591/202107245
 conference: icml
 year: 2021
 tags: icml-2021

--- a/_posts/2021_icml/2021-07-07-gilberto.md
+++ b/_posts/2021_icml/2021-07-07-gilberto.md
@@ -9,7 +9,7 @@ pitch: https://www.youtube.com/watch?v=W9g_on1ITFA&list=PLFHvi5sdWF5VqqqQvVC5SuB
 type: Oral
 topic: Applications
 category: Extended Abstract
-link: https://research.latinxinai.org/papers/icml/2021/pdf/paper_04.pdf
+link: https://doi.org/10.52591/202107241
 conference: icml
 year: 2021
 tags: icml-2021

--- a/_posts/2021_icml/2021-07-07-igor.md
+++ b/_posts/2021_icml/2021-07-07-igor.md
@@ -9,7 +9,7 @@ pitch: https://www.youtube.com/watch?v=KbBIG2TCxX4&list=PLFHvi5sdWF5VqqqQvVC5SuB
 type: Oral
 topic: Applications
 category: Extended Abstract
-link: https://research.latinxinai.org/papers/icml/2021/pdf/paper_06.pdf
+link: https://doi.org/10.52591/202107243
 conference: icml
 year: 2021
 tags: icml-2021

--- a/_posts/2021_icml/2021-07-07-lincoln.md
+++ b/_posts/2021_icml/2021-07-07-lincoln.md
@@ -9,7 +9,7 @@ pitch: https://www.youtube.com/watch?v=HA1i7CFChu0&list=PLFHvi5sdWF5VqqqQvVC5SuB
 type: Oral
 topic: Deep Learning
 category: Extended Abstract
-link: https://research.latinxinai.org/papers/icml/2021/pdf/paper_26.pdf
+link: https://doi.org/10.52591/202107249
 conference: icml
 year: 2021
 tags: icml-2021

--- a/_posts/2021_icml/2021-07-07-lucia.md
+++ b/_posts/2021_icml/2021-07-07-lucia.md
@@ -9,7 +9,7 @@ pitch: https://www.youtube.com/watch?v=5I7cGDEuy0s&list=PLFHvi5sdWF5VqqqQvVC5SuB
 type: Oral
 topic: Deep Learning
 category: Extended Abstract
-link: https://research.latinxinai.org/papers/icml/2021/pdf/paper_19.pdf
+link: https://doi.org/10.52591/202107247
 conference: icml
 year: 2021
 tags: icml-2021

--- a/_posts/2021_icml/2021-07-07-malolan.md
+++ b/_posts/2021_icml/2021-07-07-malolan.md
@@ -9,7 +9,7 @@ pitch: https://www.youtube.com/watch?v=FRBayZFv258&list=PLFHvi5sdWF5VqqqQvVC5SuB
 type: Oral
 topic: Applications
 category: Extended Abstract
-link: https://research.latinxinai.org/papers/icml/2021/pdf/paper_33.pdf
+link: https://doi.org/10.52591/2021072413
 conference: icml
 year: 2021
 tags: icml-2021

--- a/_posts/2021_icml/2021-07-07-miguel.md
+++ b/_posts/2021_icml/2021-07-07-miguel.md
@@ -9,7 +9,7 @@ pitch: https://www.youtube.com/watch?v=GYB9vLuIp3A&list=PLFHvi5sdWF5VqqqQvVC5SuB
 type: Oral
 topic: Machine Learning
 category: Extended Abstract
-link: https://research.latinxinai.org/papers/icml/2021/pdf/paper_05.pdf
+link: https://doi.org/10.52591/202107242
 conference: icml
 year: 2021
 tags: icml-2021


### PR DESCRIPTION
Added all DOI links and the links in the citation column now open in a new tab.