### PR TITLE
ICML 2021 - Paper ID 28, 29 and 32 PDF Links Broken

### DIFF
--- a/_includes/workshops/icml/icml2021.html
+++ b/_includes/workshops/icml/icml2021.html
@@ -100,7 +100,7 @@
               <td class="tg-0lax">{{paper.author}}</td>
               <td class="tg-0lax">
                 <br>
-                <a target="_blank" href="../../../papers/{{paper.conference}}/{{paper.year}}/pdf/{{paper.poster}}.pdf"><img src="../../../assets/icons/pdf2.png" height="30"></a>
+                <a target="_blank" href="../../../papers/{{paper.conference}}/{{paper.year}}/pdf/{{paper.pdf}}"><img src="../../../assets/icons/pdf2.png" height="30"></a>
               </td>
               <td class="tg-0lax">
                 <br>


### PR DESCRIPTION
Probably made this mistake when fixing issue #67. Sorry!