### PR TITLE
Amend titles in tables to match exactly with titles in the paper submitted. (Reflect final title from camera-ready version)

### DIFF
--- a/_posts/2019_icml/2019-06-15-Bejar.md
+++ b/_posts/2019_icml/2019-06-15-Bejar.md
@@ -2,7 +2,7 @@
 paperId: 34
 author: Hans Harley Bejar Ccacyahuillca
 publicationauthor: Bejar Ccacyahuillca, H. H.
-title: Relative Fuzzy Connectedness on Directed Graphs and its Application in a Hybrid Method for Interactive Image Segmentation
+title: "Oriented relative fuzzy connectedness: theory, algorithms, and its applications in hybrid image segmentation methods"
 pdf: Poster_Hans_BejarV2
 poster: Poster_Hans_Bejar
 alt: --

--- a/_posts/2019_icml/2019-06-15-Cardenas.md
+++ b/_posts/2019_icml/2019-06-15-Cardenas.md
@@ -2,7 +2,7 @@
 paperId: 29
 author: Ana Rocio Cardenas Maita
 publicationauthor: Cardenas Maita, A. R.
-title: A study of the application of computational intelligence and machine learning techniques in business process mining - A brief
+title: A study of the application of computational intelligence and machine learning techniques in business process mining
 pdf: Poster_Ana_CardenasV2
 poster: Poster_Ana_Cardenas
 alt: --

--- a/_posts/2021_cvpr/2021-05-06-byrd.md
+++ b/_posts/2021_cvpr/2021-05-06-byrd.md
@@ -2,7 +2,7 @@
 paperId: 51
 author: Byrd, Emmanuel; Gonzalez-Mendoza, Miguel
 publicationauthor: Byrd, E. et al.
-title: "ActivityNet and OSCAR: an Image Captioning model can effectively learn a Video Captioning dataset"
+title: "OSCAR and ActivityNet: an Image Captioning model can effectively learn a Video Captioning dataset"
 pdf: 51_CameraReady_51.pdf
 poster: 51_poster_51.png
 pitch: https://youtu.be/7rpquhEAW_o

--- a/_posts/2021_cvpr/2021-05-06-ciprian.md
+++ b/_posts/2021_cvpr/2021-05-06-ciprian.md
@@ -2,7 +2,7 @@
 paperId: 39
 author: Ciprián-Sánchez, Jorge F; Ochoa-Ruiz, Gilberto; Rossi, Lucile
 publicauthor: Ciprián-Sánchez, J. F. et al.
-title: "Assessing the impact of visible-infrared image fusion strategies for Deep Learning-based wildfire segmentation"
+title: "Assessing the impact of the loss function, architecture and image type for Deep Learning-based wildfire segmentation"
 pdf: 39_CameraReady_39.pdf
 poster: 39_poster_39.png
 pitch: https://youtu.be/ALFmUuG-xuQ

--- a/_posts/2021_cvpr/2021-05-06-pestana.md
+++ b/_posts/2021_cvpr/2021-05-06-pestana.md
@@ -2,7 +2,7 @@
 paperId: 4
 author: Pestana, Camilo Andres Pestana; Glance, David; Liu, Wei; Owens, Robyn A; Mian, Ajmal
 publicationauthor: Pestana, C. A. P. et al.
-title: "Assistive signals for deep neural network classifiers"
+title: "Assistive Signals for Deep Neural Network Classifiers"
 pdf: 4_CameraReady_04.pdf
 poster: 4_poster_04.png
 pitch: https://youtu.be/6f803hsdbw4

--- a/_posts/2021_icml/2021-07-07-alberto.md
+++ b/_posts/2021_icml/2021-07-07-alberto.md
@@ -2,7 +2,7 @@
 paperId: 35
 author: Alberto Rodrigues Ferreira; Alex Akira Okuno
 publicationauthor: Okuno, A. A. et al.
-title: Generalized linear tree, a flexible algorithm for predicting continuous variables
+title: "Generalized linear tree: a flexible algorithm for predicting continuous variables"
 pdf: paper_35.pdf
 poster: poster_35.png
 pitch: https://www.youtube.com/watch?v=qbDyhRw1e-I&list=PLFHvi5sdWF5VqqqQvVC5SuBY7ecSgqequ&index=30

--- a/_posts/2021_icml/2021-07-07-alexander.md
+++ b/_posts/2021_icml/2021-07-07-alexander.md
@@ -2,7 +2,7 @@
 paperId: 12
 author: Alexander Kalen Targa; Alberto Landi Cortiñas; Nicolas Araque Volk; Alejandro Marcano Van Grieken 
 publicationauthor: Kalen Targa, A. et al.
-title: Mask-net, Detection of Correct Use of Masks Through Computer Vision
+title: "Mask-net: Detection of Correct Use of Masks Through Computer Vision"
 pdf: paper_12.pdf
 poster: poster_12.png
 pitch: https://www.youtube.com/watch?v=nwK7eNK0auc&list=PLFHvi5sdWF5VqqqQvVC5SuBY7ecSgqequ&index=15

--- a/_posts/2021_icml/2021-07-07-daniel.md
+++ b/_posts/2021_icml/2021-07-07-daniel.md
@@ -2,7 +2,7 @@
 paperId: 21
 author: Daniel E Ochoa; Jorge I. Poveda; Cesar Uribe
 publicationauthor: Ochoa, D. E. et al.
-title: "Computation-Aware Distributed Optimization over Networks: A Hybrid Dynamical Systems Approach"
+title: "Towards Computation-Aware Distributed Optimization over Networks"
 pdf: paper_21.pdf
 poster: poster_21.png
 pitch: https://www.youtube.com/watch?v=252t4hg7dMc&list=PLFHvi5sdWF5VqqqQvVC5SuBY7ecSgqequ&index=13

--- a/_posts/2021_icml/2021-07-07-federico.md
+++ b/_posts/2021_icml/2021-07-07-federico.md
@@ -2,7 +2,7 @@
 paperId: 16
 author: Federico Albanese; Esteban Feuerstein 
 publicationauthor: Albanese, F. et al.
-title: Community pooling, LDA topic modeling in Twitter
+title: "Community pooling: LDA topic modeling in Twitter"
 pdf: paper_16.pdf
 poster: poster_16.png
 pitch: https://www.youtube.com/watch?v=Eo5nqMn4ekE&list=PLFHvi5sdWF5VqqqQvVC5SuBY7ecSgqequ&index=14


### PR DESCRIPTION
Reviewed and fixed the titles for ICML 2019 and 2021, and CVPR 2021 papers. Now all titles in the tables match their respective papers for every workshop.